### PR TITLE
'fix' building document with XeLaTeX

### DIFF
--- a/latex/mi-document/mi-document.cls
+++ b/latex/mi-document/mi-document.cls
@@ -23,7 +23,7 @@
 \ProvidesClass{mi-document}[2016/07/15 v2.0 mi-document]
 \LoadClass[12pt,a4paper,oneside,ngerman]{scrartcl}
 
-\usepackage[T1]{fontenc}
+\usepackage{fontspec}
 \usepackage{ngerman}
 \usepackage{xunicode}
 \usepackage{polyglossia}


### PR DESCRIPTION
-- sorry no latex guru here --

Following error occured for me using the 
> \usepackage[T1]{fontenc}


> Command \\nobreakspace unavailable in encoding TU.

According to https://tex.stackexchange.com/questions/66949/command-nobreakspace-unavailable-when-switching-to-t1-encoding-under-xelatex i changed line 26. 
Now the document is building again. 

Of course this is just a proposal to fix the build. 
Maybe someone knows a better approach. 

I know there isn't much recent activity on this repository and some packages may be outdated. 
So if someone has a more up to date template i would appreciate.